### PR TITLE
Add option for plain text output

### DIFF
--- a/src/getopts.js
+++ b/src/getopts.js
@@ -8,6 +8,7 @@ export default async argv => {
     .option('-j, --json', 'Force JSON output')
     .option('-y, --yaml', 'YAML output')
     .option('-a, --accept-yaml', 'YAML input')
+    .option('-p, --plain-text', 'Do not decorate output')
     .option('-q, --query-file <path>', 'JSONata query file')
     .parse(argv)
 
@@ -15,11 +16,12 @@ export default async argv => {
   const json = !!program.json
   const yamlOut = !!program.yaml
   const yamlIn = !!program.acceptYaml
+  const plainText = !!program.plainText
   const queryFile = program.queryFile
   const files = program.args.slice(0)
 
   const query = await getQuery(queryFile, files)
-  return { query, files, ndjson, json, yamlOut, yamlIn }
+  return { query, files, ndjson, json, yamlOut, yamlIn, plainText }
 }
 
 const getQuery = async (queryFile, files) => {

--- a/src/jfq.js
+++ b/src/jfq.js
@@ -6,7 +6,7 @@ import getopts from './getopts'
 import YAML from 'js-yaml'
 
 const main = async () => {
-  const { files, ndjson, json, yamlIn, yamlOut, query } = await getopts(process.argv)
+  const { files, ndjson, json, yamlIn, yamlOut, query, plainText } = await getopts(process.argv)
   const evaluator = parseQuery(query)
   const data = await readInput(files)
 
@@ -16,7 +16,7 @@ const main = async () => {
     } else {
       const input = yamlIn ? parseYaml(file.data, file.name) : parseJson(file.data, file.name)
       const result = evaluator.evaluate(input)
-      const output = yamlOut ? formatYaml(result) : formatJson(result, ndjson, json)
+      const output = yamlOut ? formatYaml(result) : formatJson(result, ndjson, json, plainText)
       console.log(output)
     }
   })
@@ -30,7 +30,7 @@ const parseQuery = query => {
   }
 }
 
-const formatJson = (data, ndjson, json) => {
+const formatJson = (data, ndjson, json, plainText) => {
   if (typeof data === 'undefined') {
     return ''
   }
@@ -46,7 +46,7 @@ const formatJson = (data, ndjson, json) => {
   }
 
   const formatted = ndjson ? JSON.stringify(data) : JSON.stringify(data, null, 2)
-  return colorize(formatted)
+  return plainText ? formatted : colorize(formatted)
 }
 
 // Is it an array containing only simple types

--- a/src/test-helper.js
+++ b/src/test-helper.js
@@ -4,7 +4,7 @@ export const run = (...parms) => exec(command(parms))
 
 export const runStdin = (stdin, ...parms) => exec(`echo '${stdin}' | ` + command(parms))
 
-const command = parms => './bin/jfq.js ' + parms.join(' ')
+const command = parms => './bin/jfq.js -p ' + parms.join(' ')
 
 const exec = command => {
   const cliTest = new CliTest()


### PR DESCRIPTION
Some updates to Jest seem to be doing stronger text matching and
the colorized output is causing test failures.  We should have a
plain text option, and always use this in tests.