### PR TITLE
fix: ENAMETOOLONG when query is long

### DIFF
--- a/src/__tests__/getopts.js
+++ b/src/__tests__/getopts.js
@@ -29,6 +29,15 @@ describe('getting command line options', () => {
     })
   })
 
+  describe('when the first argument is too long to be a file name', () => {
+    it('reads it as a query', async () => {
+      const longquery = 'stuff'.repeat(1000)
+      const res = await getopts(fakeArgv(longquery, 'fake.file'))
+      expect(res.query).toEqual(longquery)
+      expect(res.files).toEqual(['fake.file'])
+    })
+  })
+
   describe('when a query file is specified', () => {
     it('reads the query from the file', async () => {
       const res = await getopts(fakeArgv('-q', './src/__tests__/fixtures/query.jsonata'))

--- a/src/getopts.js
+++ b/src/getopts.js
@@ -24,13 +24,21 @@ export default async argv => {
   return { query, files, ndjson, json, yamlOut, yamlIn, plainText }
 }
 
+const exists = async (path) => {
+  try {
+    return await fileExists(path)
+  } catch (err) {
+    return false
+  }
+}
+
 const getQuery = async (queryFile, files) => {
   if (typeof queryFile === 'string' && queryFile.length) {
     return readFilePromise(queryFile, 'utf8')
   } else {
     // If the first argument is a file that exists, then it was not a query string
     // If the first argument is not defined, then it was not a query string
-    const isNotQuery = files[0] ? await fileExists(files[0]) : true
+    const isNotQuery = files[0] ? await exists(files[0]) : true
     return (isNotQuery ? '$' : files.shift())
   }
 }


### PR DESCRIPTION
The first argument may be a query or a file name. When it's intended to be a query, and the string is too long to be a file name, then users should not see an error.

Resolves https://github.com/blgm/jfq/issues/419