### PR TITLE
chore: drop 'command-line-test' dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4567,12 +4567,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
-    "command-line-test": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/command-line-test/-/command-line-test-1.0.10.tgz",
-      "integrity": "sha1-eJfGgHapz7alPnivBpwxa1GF7n0=",
-      "dev": true
-    },
     "commander": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@babel/preset-env": "7.20.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "29.4.2",
-    "command-line-test": "1.0.10",
     "jest": "29.4.2",
     "markdown-link-check": "3.10.3",
     "regenerator-runtime": "0.13.11",

--- a/src/__tests__/jfq_inputs.js
+++ b/src/__tests__/jfq_inputs.js
@@ -49,15 +49,11 @@ describe('inputs', () => {
     it('reports the position in STDIN', async () => {
       const input = '{"foo": bar'
       const res = await runStdin(input)
-      expect(res.stderr).toBeNull()
-      expect(res.stdout).toBeNull()
       expect(res.error.message).toContain('Unexpected token "b" (0x62) in JSON at position 8 while parsing "{\\"foo\\": bar\\n"')
     })
 
     it('reports the position and file name for files', async () => {
       const res = await run('$', 'src/__tests__/fixtures/bad.json')
-      expect(res.stderr).toBeNull()
-      expect(res.stdout).toBeNull()
       expect(res.error.message).toContain('Unexpected token "f" (0x66) in JSON at position 4 while parsing "{\\n  foo: 42\\n}\\n" in src/__tests__/fixtures/bad.json')
     })
   })
@@ -73,15 +69,11 @@ describe('inputs', () => {
     describe('parse errors', () => {
       it('reports the file name', async () => {
         const res = await run('-a', '$', 'src/__tests__/fixtures/bad.yaml')
-        expect(res.stderr).toBeNull()
-        expect(res.stdout).toBeNull()
         expect(res.error.message).toContain('in file src/__tests__/fixtures/bad.yaml')
       })
 
       it('does not report file names with stdin', async () => {
         const res = await runStdin('{foo}}', '-a')
-        expect(res.stderr).toBeNull()
-        expect(res.stdout).toBeNull()
         expect(res.error.message).toContain('end of the stream or a document separator is expected (1:6)')
       })
     })
@@ -90,8 +82,6 @@ describe('inputs', () => {
   describe('files not found', () => {
     it('reports the error', async () => {
       const res = await run('$', 'not_here_sucker.json')
-      expect(res.stderr).toBeNull()
-      expect(res.stdout).toBeNull()
       expect(res.error.message).toContain("ENOENT: no such file or directory, open 'not_here_sucker.json'")
     })
   })

--- a/src/__tests__/jfq_query.js
+++ b/src/__tests__/jfq_query.js
@@ -17,8 +17,6 @@ describe('queries', () => {
   describe('invalid', () => {
     it('returns the error from JSONata', async () => {
       const result = await run('na!me', 'package.json')
-      expect(result.stderr).toBeNull()
-      expect(result.stdout).toBeNull()
       expect(result.error.message).toContain('Failed to compile JSONata expression: Unknown operator: "!"')
     })
   })

--- a/src/test-helper.js
+++ b/src/test-helper.js
@@ -1,12 +1,19 @@
-import CliTest from 'command-line-test'
+import childProcess from 'child_process'
 
 export const run = (...parms) => exec(command(parms))
 
 export const runStdin = (stdin, ...parms) => exec(`echo '${stdin}' | ` + command(parms))
 
-const command = parms => './bin/jfq.js -p ' + parms.join(' ')
+const command = params => './bin/jfq.js -p ' + params.join(' ')
 
 const exec = command => {
-  const cliTest = new CliTest()
-  return cliTest.exec(command)
+  return new Promise(resolve => {
+    childProcess.exec(command, (error, stdout, stderr) => {
+      resolve({
+        error,
+        stdout: stdout.trim(),
+        stderr: stderr.trim()
+      })
+    })
+  })
 }


### PR DESCRIPTION
There is a security advisory for this module with no fix: https://github.com/advisories/GHSA-q752-wh6j-w944