### PR TITLE
chore: drop 'parse-json' dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
       "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
@@ -1410,6 +1411,7 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
       "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -4745,6 +4747,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -5321,7 +5324,8 @@
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "execa": {
       "version": "5.1.1",
@@ -5749,7 +5753,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-bigint": {
       "version": "1.0.4",
@@ -7386,7 +7391,8 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -7420,7 +7426,8 @@
     "json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -7470,7 +7477,8 @@
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
     },
     "link-check": {
       "version": "5.2.0",
@@ -8018,6 +8026,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "js-yaml": "^4.1.0",
     "json-colorizer": "^2.2.2",
     "jsonata": "^2.0.1",
-    "parse-json": "^5.2.0",
     "read-input": "^0.3.1"
   },
   "bin": "bin/jfq.js"

--- a/src/__tests__/jfq_inputs.js
+++ b/src/__tests__/jfq_inputs.js
@@ -49,12 +49,12 @@ describe('inputs', () => {
     it('reports the position in STDIN', async () => {
       const input = '{"foo": bar'
       const res = await runStdin(input)
-      expect(res.error.message).toContain('Unexpected token "b" (0x62) in JSON at position 8 while parsing "{\\"foo\\": bar\\n"')
+      expect(res.error.message).toContain('Unexpected token b in JSON at position 8')
     })
 
     it('reports the position and file name for files', async () => {
       const res = await run('$', 'src/__tests__/fixtures/bad.json')
-      expect(res.error.message).toContain('Unexpected token "f" (0x66) in JSON at position 4 while parsing "{\\n  foo: 42\\n}\\n" in src/__tests__/fixtures/bad.json')
+      expect(res.error.message).toContain('Unexpected token f in JSON at position 4 in file src/__tests__/fixtures/bad.json')
     })
   })
 

--- a/src/jfq.js
+++ b/src/jfq.js
@@ -1,6 +1,5 @@
 import colorize from 'json-colorizer'
 import jsonata from 'jsonata'
-import parseJson from 'parse-json'
 import readInput from 'read-input'
 import getopts from './getopts'
 import YAML from 'js-yaml'
@@ -65,6 +64,18 @@ const parseYaml = (string, fileName) => {
 }
 
 const formatYaml = yaml => typeof yaml === 'undefined' ? '' : YAML.dump(yaml)
+
+const parseJson = (string, fileName) => {
+  try {
+    return JSON.parse(string)
+  } catch (err) {
+    if (fileName) {
+      throw new Error(err.message + ' in file ' + fileName)
+    } else {
+      throw err
+    }
+  }
+}
 
 main()
   .catch(err => {


### PR DESCRIPTION
Node.js JSON parser now has slightly better errors, so it's not worth having an extra dependency